### PR TITLE
Add Timestamp to alert message + fix clipping bug

### DIFF
--- a/wifi-tout.xcodeproj/project.pbxproj
+++ b/wifi-tout.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		694ED7271B020C1B66981983 /* DateTimeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694ED22AA68220FCF2FEDB36 /* DateTimeFactory.swift */; };
+		694EDE38C5D934BCC74A73D8 /* LocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694EDDED8BC6523C29F2806D /* LocaleProvider.swift */; };
 		7228F40723E86EDB009D20B7 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7228F40623E86EDB009D20B7 /* Reachability.swift */; };
 		72C33EA423E0C4DD00A94D03 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C33EA323E0C4DD00A94D03 /* AppDelegate.swift */; };
 		72C33EA623E0C4DD00A94D03 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C33EA523E0C4DD00A94D03 /* ContentView.swift */; };
@@ -17,6 +19,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		694ED22AA68220FCF2FEDB36 /* DateTimeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTimeFactory.swift; sourceTree = "<group>"; };
+		694EDDED8BC6523C29F2806D /* LocaleProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleProvider.swift; sourceTree = "<group>"; };
 		7228F40623E86EDB009D20B7 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		72C33EA023E0C4DD00A94D03 /* wifi-tout.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "wifi-tout.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		72C33EA323E0C4DD00A94D03 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -68,6 +72,8 @@
 				72C33EAF23E0C4DE00A94D03 /* Info.plist */,
 				72C33EB023E0C4DE00A94D03 /* wifi_tout.entitlements */,
 				72C33EA923E0C4DE00A94D03 /* Preview Content */,
+				694ED22AA68220FCF2FEDB36 /* DateTimeFactory.swift */,
+				694EDDED8BC6523C29F2806D /* LocaleProvider.swift */,
 			);
 			path = "wifi-tout";
 			sourceTree = "<group>";
@@ -155,6 +161,8 @@
 				72C33EA623E0C4DD00A94D03 /* ContentView.swift in Sources */,
 				72C33EA423E0C4DD00A94D03 /* AppDelegate.swift in Sources */,
 				7228F40723E86EDB009D20B7 /* Reachability.swift in Sources */,
+				694ED7271B020C1B66981983 /* DateTimeFactory.swift in Sources */,
+				694EDE38C5D934BCC74A73D8 /* LocaleProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -293,7 +301,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"wifi-tout/Preview Content\"";
-				DEVELOPMENT_TEAM = NQR363YYF4;
+				DEVELOPMENT_TEAM = PD5QMARB3X;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "wifi-tout/Info.plist";
@@ -317,7 +325,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"wifi-tout/Preview Content\"";
-				DEVELOPMENT_TEAM = NQR363YYF4;
+				DEVELOPMENT_TEAM = PD5QMARB3X;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "wifi-tout/Info.plist";

--- a/wifi-tout/ContentView.swift
+++ b/wifi-tout/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
                 .onReceive(timer) { _ in
                     self.onNextReachabilityTick()
                 }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private func onNextReachabilityTick() {

--- a/wifi-tout/DateTimeFactory.swift
+++ b/wifi-tout/DateTimeFactory.swift
@@ -1,0 +1,22 @@
+//
+// Created by Kelvin Harron on 05/02/2020.
+// Copyright (c) 2020 Matthew Wilson. All rights reserved.
+//
+
+import Foundation
+
+class DateTimeFactory {
+
+    private let dateFormatter = DateFormatter()
+    private let localeProvider = LocaleProvider()
+
+    private let dateTimeFormatMedium = "MMM d, h:mm a"
+
+    func getFormattedDate() -> String {
+        let timestamp = Date()
+        dateFormatter.locale = localeProvider.getUserLocale()
+        dateFormatter.dateFormat = dateTimeFormatMedium
+
+        return dateFormatter.string(from: timestamp)
+    }
+}

--- a/wifi-tout/LocaleProvider.swift
+++ b/wifi-tout/LocaleProvider.swift
@@ -1,0 +1,13 @@
+//
+// Created by Kelvin Harron on 05/02/2020.
+// Copyright (c) 2020 Matthew Wilson. All rights reserved.
+//
+
+import Foundation
+
+class LocaleProvider {
+
+    func getUserLocale() -> Locale {
+        Locale.current
+    }
+}

--- a/wifi-tout/NotificationService.swift
+++ b/wifi-tout/NotificationService.swift
@@ -9,13 +9,17 @@
 import Foundation
 import UserNotifications
 
+
 class NotificationService {
-    
+
+    private let dateTimeFactory = DateTimeFactory()
+
     func emitWifiDownNotification() {
         print("emitting notification")
         let content = UNMutableNotificationContent()
+        let contentBody = "Was unable to reach the internet at " + dateTimeFactory.getFormattedDate()
         content.title = "Wifi is down"
-        content.body = "Was unable to reach google.com"
+        content.body = contentBody
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
 
@@ -30,5 +34,4 @@ class NotificationService {
            }
         }
     }
-    
 }


### PR DESCRIPTION
Using short form datetime format to display timestamp on disconnect,
- updated notification to read reach the internet as google is not explicitly hit anymore.
- fixed bug where wifi not connected message was clipped off on display in popover.

Can we ignore or fix the dev team stuff being commited to the project @matthewwilson ?