### PR TITLE
Add Event Logging + update notification time and date + check reachability every 5 seconds

### DIFF
--- a/wifi-tout.xcodeproj/project.pbxproj
+++ b/wifi-tout.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		694ED5DAC7011ED77E206E97 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694EDE01FEB918FE9212E81C /* EventLogger.swift */; };
 		694ED7271B020C1B66981983 /* DateTimeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694ED22AA68220FCF2FEDB36 /* DateTimeFactory.swift */; };
 		694EDE38C5D934BCC74A73D8 /* LocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694EDDED8BC6523C29F2806D /* LocaleProvider.swift */; };
 		7228F40723E86EDB009D20B7 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7228F40623E86EDB009D20B7 /* Reachability.swift */; };
@@ -21,6 +22,7 @@
 /* Begin PBXFileReference section */
 		694ED22AA68220FCF2FEDB36 /* DateTimeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTimeFactory.swift; sourceTree = "<group>"; };
 		694EDDED8BC6523C29F2806D /* LocaleProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleProvider.swift; sourceTree = "<group>"; };
+		694EDE01FEB918FE9212E81C /* EventLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		7228F40623E86EDB009D20B7 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		72C33EA023E0C4DD00A94D03 /* wifi-tout.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "wifi-tout.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		72C33EA323E0C4DD00A94D03 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				72C33EA923E0C4DE00A94D03 /* Preview Content */,
 				694ED22AA68220FCF2FEDB36 /* DateTimeFactory.swift */,
 				694EDDED8BC6523C29F2806D /* LocaleProvider.swift */,
+				694EDE01FEB918FE9212E81C /* EventLogger.swift */,
 			);
 			path = "wifi-tout";
 			sourceTree = "<group>";
@@ -163,6 +166,7 @@
 				7228F40723E86EDB009D20B7 /* Reachability.swift in Sources */,
 				694ED7271B020C1B66981983 /* DateTimeFactory.swift in Sources */,
 				694EDE38C5D934BCC74A73D8 /* LocaleProvider.swift in Sources */,
+				694ED5DAC7011ED77E206E97 /* EventLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -298,6 +302,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "wifi-tout/wifi_tout.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"wifi-tout/Preview Content\"";
@@ -322,6 +327,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "wifi-tout/wifi_tout.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"wifi-tout/Preview Content\"";

--- a/wifi-tout/AppDelegate.swift
+++ b/wifi-tout/AppDelegate.swift
@@ -13,12 +13,14 @@ import UserNotifications
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-    var window: NSWindow!
-    var popover: NSPopover!
-    var statusBarItem: NSStatusItem!
+    private var window: NSWindow!
+    private var popover: NSPopover!
+    private var statusBarItem: NSStatusItem!
+    private let eventLogger = EventLogger()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Create the SwiftUI view that provides the window contents.
+        eventLogger.logAppStartup()
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             // Enable or disable features based on authorization.
@@ -45,7 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
+        eventLogger.logAppTerminated()
     }
     
     @objc func togglePopover(_ sender: AnyObject?) {

--- a/wifi-tout/ContentView.swift
+++ b/wifi-tout/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     @State private var status = "Connected to WiFi"
     private let reachability = Reachability()
     private let notificationService = NotificationService()
-    private let timer = Timer.publish(every: 20, on: .main, in: .common).autoconnect()
+    private let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some View {
         VStack(alignment: .center, spacing: 5) {
@@ -49,7 +49,7 @@ struct ContentView: View {
         Button(action: {
             NSApplication.shared.terminate(self)
         }) {
-            Text("Quit Wifi-tout?")
+            Text("Quit WiFi-tout")
                     .foregroundColor(.white)
         }
     }

--- a/wifi-tout/DateTimeFactory.swift
+++ b/wifi-tout/DateTimeFactory.swift
@@ -9,13 +9,14 @@ class DateTimeFactory {
 
     private let dateFormatter = DateFormatter()
     private let localeProvider = LocaleProvider()
+    private let twentyFourHourFormat = "HH:mm"
 
-    private let dateTimeFormatMedium = "MMM d, h:mm a"
-
-    func getFormattedDate() -> String {
+    func getFormattedTime() -> String {
         let timestamp = Date()
+
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .short
         dateFormatter.locale = localeProvider.getUserLocale()
-        dateFormatter.dateFormat = dateTimeFormatMedium
 
         return dateFormatter.string(from: timestamp)
     }

--- a/wifi-tout/EventLogger.swift
+++ b/wifi-tout/EventLogger.swift
@@ -1,0 +1,40 @@
+//
+// Created by Kelvin Harron on 09/02/2020.
+// Copyright (c) 2020 Matthew Wilson. All rights reserved.
+//
+
+import Foundation
+import os
+
+class EventLogger {
+
+    func logWifiTouting() {
+        os_log("Was unable to reach the internet", log: OSLog.app, type: .error)
+    }
+
+    func logAppStartup() {
+        os_log("Wifi tout started", log: OSLog.app, type: .error)
+    }
+
+    func logAppTerminated() {
+        os_log("Wifi tout stopped", log: OSLog.app, type: .error)
+    }
+
+    private func getIdentifier() -> String {
+        if let bundleIdentifier = Bundle.main.bundleIdentifier {
+            return bundleIdentifier
+        } else {
+            return "so.mwil.wifi-tout"
+        }
+    }
+}
+
+extension OSLog {
+    static let app = OSLog(category: "Application")
+    static let event = OSLog(category: "Event")
+
+    private convenience init(category: String, bundle: Bundle = Bundle.main) {
+        let identifier = bundle.infoDictionary?["CFBundleIdentifier"] as? String ?? "so.mwil.wifi-tout"
+        self.init(subsystem: (identifier).appending(".logs"), category: category)
+    }
+}

--- a/wifi-tout/NotificationService.swift
+++ b/wifi-tout/NotificationService.swift
@@ -9,29 +9,35 @@
 import Foundation
 import UserNotifications
 
-
 class NotificationService {
 
     private let dateTimeFactory = DateTimeFactory()
+    private let eventLogger = EventLogger()
 
     func emitWifiDownNotification() {
-        print("emitting notification")
-        let content = UNMutableNotificationContent()
-        let contentBody = "Was unable to reach the internet at " + dateTimeFactory.getFormattedDate()
-        content.title = "Wifi is down"
-        content.body = contentBody
+        print("Emitting wifi interrupted notification")
+        eventLogger.logWifiTouting()
 
+        let notificationContent = buildNotificationContent()
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: notificationContent, trigger: trigger)
 
-        let uuidString = UUID().uuidString
-        let request = UNNotificationRequest(identifier: uuidString, content: content, trigger: trigger)
+        dispatchNotification(with: request)
+    }
 
-        // Schedule the request with the system.
+    private func buildNotificationContent() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "WiFi interrupted"
+        content.body = "Was unable to reach the internet at " + dateTimeFactory.getFormattedTime()
+        return content
+    }
+
+    private func dispatchNotification(with request: UNNotificationRequest) {
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.add(request) { (error) in
-           if error != nil {
-            print("\(error!.localizedDescription)")
-           }
+            if error != nil {
+                print("\(error!.localizedDescription)")
+            }
         }
     }
 }


### PR DESCRIPTION
- Add EventLogger.swift, writing to the unified macOS logger when app start, terminate and wifi interrupted,
- Update ContentView.swift timer to publish update every 5 seconds instead of 20,
- Update DateTimeFactory.swift to return current time in 24 hour format time only,
- Tidy up NotificationService.swift code, edited title to output "WiFi interrupted"

@matthewwilson XCTest stresses me out pls help 